### PR TITLE
chore: upgrade to 0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This module will also generate to image name to output.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_kaniko"></a> [kaniko](#requirement\_kaniko) | 0.0.1-dev1 |
+| <a name="requirement_kaniko"></a> [kaniko](#requirement\_kaniko) | 0.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kaniko"></a> [kaniko](#provider\_kaniko) | 0.0.1-dev1 |
+| <a name="provider_kaniko"></a> [kaniko](#provider\_kaniko) | 0.0.2 |
 
 ## Modules
 
@@ -24,7 +24,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [kaniko_image.image](https://registry.terraform.io/providers/gitlawr/kaniko/0.0.1-dev1/docs/resources/image) | resource |
+| [kaniko_image.image](https://registry.terraform.io/providers/seal-io/kaniko/0.0.2/docs/resources/image) | resource |
 
 ## Inputs
 
@@ -53,13 +53,13 @@ No modules.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_kaniko"></a> [kaniko](#requirement\_kaniko) | 0.0.1 |
+| <a name="requirement_kaniko"></a> [kaniko](#requirement\_kaniko) | 0.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kaniko"></a> [kaniko](#provider\_kaniko) | 0.0.1 |
+| <a name="provider_kaniko"></a> [kaniko](#provider\_kaniko) | 0.0.2 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
 
 ## Modules
@@ -73,7 +73,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [kaniko_image.image](https://registry.terraform.io/providers/seal-io/kaniko/0.0.1/docs/resources/image) | resource |
+| [kaniko_image.image](https://registry.terraform.io/providers/seal-io/kaniko/0.0.2/docs/resources/image) | resource |
 | [kubernetes_service.service](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/service) | data source |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kaniko = {
       source  = "seal-io/kaniko"
-      version = "0.0.1"
+      version = "0.0.2"
     }
   }
 }
@@ -36,7 +36,7 @@ module "deployment" {
 
   # Use local paths to avoid accessing external networks
   # This module comes from terraform registry "terraform-iaac/deployment/kubernetes 1.4.2"
-  source  = "./modules/deployment/kubernetes"
+  source = "./modules/deployment/kubernetes"
 
   name      = local.name
   namespace = local.namespace
@@ -56,7 +56,7 @@ module "service" {
 
   # Use local paths to avoid accessing external networks
   # This module comes from terraform registry "terraform-iaac/service/kubernetes 1.0.4"
-  source  = "./modules/service/kubernetes"
+  source = "./modules/service/kubernetes"
 
   app_name      = local.name
   app_namespace = local.namespace
@@ -84,7 +84,7 @@ data "kubernetes_service" "service" {
 ########
 
 locals {
-  name      = coalesce(var.name, "${var.walrus_metadata_service_name}")
-  namespace = coalesce(var.namespace, var.walrus_metadata_namespace_name)
+  name           = coalesce(var.name, "${var.walrus_metadata_service_name}")
+  namespace      = coalesce(var.namespace, var.walrus_metadata_namespace_name)
   formal_git_url = replace(var.git_url, "https://", "git://")
 }


### PR DESCRIPTION
Upgrade to 0.0.2 fix can't support update resource

Issue: https://github.com/seal-io/walrus/issues/998